### PR TITLE
Fix shop bug

### DIFF
--- a/DontGetVorimed.lua
+++ b/DontGetVorimed.lua
@@ -9,7 +9,7 @@ ModUtil.RegisterMod("DontGetVorimed")
 
 local config = {
     ModName = "Dont Get Vorimed",
-    Enabled = false,
+    Enabled = true
 }
 DontGetVorimed.config = config
 DontGetVorimed.BoonTakenFlag = nil
@@ -26,25 +26,28 @@ end, DontGetVorimed)
 
 ModUtil.WrapBaseFunction("CreateLoot", function( baseFunc, args )
     local lootData = args.LootData or LootData[args.Name]
-    if DontGetVorimed.config.Enabled and not lootData.GodLoot and not DontGetVorimed.BoonTakenFlag then
+    local loot = nil
+    if config.Enabled and not lootData.GodLoot and not DontGetVorimed.BoonTakenFlag then
         LootChoiceExt.Choices = 3
         LootChoiceExt.LastLootChoices = 3
+        loot = baseFunc(args)
+        LootChoiceExt.Choices = 4
+        LootChoiceExt.LastLootChoices = 4
+    else
+        loot = baseFunc(args)
     end
 
-    return baseFunc(args)
+    return loot
 end, DontGetVorimed)
+
 
 -- After first boon reward has been selected, return to normal number of choices
 ModUtil.WrapBaseFunction("HandleUpgradeChoiceSelection", function ( baseFunc, screen, button )
-    if DontGetVorimed.config.Enabled and not DontGetVorimed.BoonTakenFlag and #GetAllUpgradeableGodTraits() == 0 then
+    if config.Enabled and not DontGetVorimed.BoonTakenFlag and #GetAllUpgradeableGodTraits() == 0 then
         if button.Data.God ~= nil then
             LootChoiceExt.Choices = 3
             LootChoiceExt.LastLootChoices = 3
             DontGetVorimed.BoonTakenFlag = true
-        else
-            -- reset to 4 options after selecting a hammer/chaos before first boon has been taken
-            LootChoiceExt.Choices = 4
-            LootChoiceExt.LastLootChoices = 4
         end
     end
 
@@ -63,7 +66,7 @@ end, DontGetVorimed)
 -- If the player ever rerolls, reduce to 3 options
 ModUtil.WrapBaseFunction("DestroyBoonLootButtons", function ( baseFunc, lootData )
     baseFunc(lootData)
-    if DontGetVorimed.config.Enabled and lootData.GodLoot and not DontGetVorimed.BoonTakenFlag then
+    if config.Enabled and lootData.GodLoot and not DontGetVorimed.BoonTakenFlag then
         LootChoiceExt.Choices = 3
         LootChoiceExt.LastLootChoices = 3
         DontGetVorimed.BoonTakenFlag = true

--- a/DontGetVorimed.lua
+++ b/DontGetVorimed.lua
@@ -27,7 +27,7 @@ end, DontGetVorimed)
 ModUtil.WrapBaseFunction("CreateLoot", function( baseFunc, args )
     local lootData = args.LootData or LootData[args.Name]
     local loot = nil
-    if config.Enabled and not lootData.GodLoot and not DontGetVorimed.BoonTakenFlag then
+    if DontGetVorimed.config.Enabled and not lootData.GodLoot and not DontGetVorimed.BoonTakenFlag then
         LootChoiceExt.Choices = 3
         LootChoiceExt.LastLootChoices = 3
         loot = baseFunc(args)
@@ -42,7 +42,7 @@ end, DontGetVorimed)
 
 -- After first boon reward has been selected, return to normal number of choices
 ModUtil.WrapBaseFunction("HandleUpgradeChoiceSelection", function ( baseFunc, screen, button )
-    if config.Enabled and not DontGetVorimed.BoonTakenFlag and #GetAllUpgradeableGodTraits() == 0 then
+    if DontGetVorimed.config.Enabled and not DontGetVorimed.BoonTakenFlag and #GetAllUpgradeableGodTraits() == 0 then
         if button.Data.God ~= nil then
             LootChoiceExt.Choices = 3
             LootChoiceExt.LastLootChoices = 3

--- a/DontGetVorimed.lua
+++ b/DontGetVorimed.lua
@@ -9,7 +9,7 @@ ModUtil.RegisterMod("DontGetVorimed")
 
 local config = {
     ModName = "Dont Get Vorimed",
-    Enabled = true
+    Enabled = false,
 }
 DontGetVorimed.config = config
 DontGetVorimed.BoonTakenFlag = nil
@@ -40,7 +40,6 @@ ModUtil.WrapBaseFunction("CreateLoot", function( baseFunc, args )
     return loot
 end, DontGetVorimed)
 
-
 -- After first boon reward has been selected, return to normal number of choices
 ModUtil.WrapBaseFunction("HandleUpgradeChoiceSelection", function ( baseFunc, screen, button )
     if config.Enabled and not DontGetVorimed.BoonTakenFlag and #GetAllUpgradeableGodTraits() == 0 then
@@ -66,7 +65,7 @@ end, DontGetVorimed)
 -- If the player ever rerolls, reduce to 3 options
 ModUtil.WrapBaseFunction("DestroyBoonLootButtons", function ( baseFunc, lootData )
     baseFunc(lootData)
-    if config.Enabled and lootData.GodLoot and not DontGetVorimed.BoonTakenFlag then
+    if DontGetVorimed.config.Enabled and lootData.GodLoot and not DontGetVorimed.BoonTakenFlag then
         LootChoiceExt.Choices = 3
         LootChoiceExt.LastLootChoices = 3
         DontGetVorimed.BoonTakenFlag = true


### PR DESCRIPTION
Previously, when a Hermes spawned in shop and was not bought dontgetvorimed would not properly activate.

Moved the choices update back to directly after the non-Olympian boon is generated rather than after it is picked up to fix this.